### PR TITLE
部屋一覧画面でレイアウトを表示できるようにした

### DIFF
--- a/src/components/button/RoomButton.tsx
+++ b/src/components/button/RoomButton.tsx
@@ -1,20 +1,21 @@
 import React from 'react'
 import { VStack, Text } from '@chakra-ui/layout'
-import { Image } from '@chakra-ui/image'
+import type { furnitureType } from '../../type/furnitureType'
+import RoomImg from '../display/RoomImg'
 
 interface Props {
   title: string
-  image: any
+  furnitureList: furnitureType[]
   type: 'green' | 'red'
   onClick: () => void
 }
 
-function RoomInfo ({ title, image, type, onClick }: Props): JSX.Element {
+function RoomInfo ({ title, furnitureList, type, onClick }: Props): JSX.Element {
   return (
     <>
-      <VStack padding='10px' rounded='5px' bg={ type === 'green' ? '#C5E8BF' : '#E8BFBF' } _hover={{ bg: type === 'green' ? '#B6D8B0' : '#E2A3A3' }} transition='.2s' cursor='pointer' onClick={onClick}>
+      <VStack padding='10px' rounded='5px' bg={ type === 'green' ? '#C5E8BF' : '#E8BFBF' } _hover={{ shadow: '2xl' }} transition='.2s' cursor='pointer' onClick={onClick}>
         <Text fontSize='20px'>{ title }</Text>
-        <Image src={image} alt='floor plan' w='200px' h='200px'/>
+        <RoomImg furnitureList={furnitureList}/>
       </VStack>
     </>
   )

--- a/src/components/display/FurnitureImg.tsx
+++ b/src/components/display/FurnitureImg.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Image } from '@chakra-ui/image'
+
+interface Props {
+  fileName: string
+  imageSize: number[]
+  position: number[]
+  rotation: number
+}
+
+function FurnitureImg ({ fileName, imageSize, position, rotation }: Props): JSX.Element {
+  return (
+    <>
+      <Image
+        position='absolute'
+        width={`${imageSize[0] * 0.2857}px`}
+        height={`${imageSize[1] * 0.2857}px`}
+        transform={`translate(${position[0] * 100 / 1.8}px, ${position[2] * 100 / 1.8}px) rotate(${rotation}deg)`}
+        objectFit='cover'
+        src={`/image_2D/${fileName}_2D.png`}
+      />
+    </>
+  )
+}
+
+export default FurnitureImg

--- a/src/components/display/RoomImg.tsx
+++ b/src/components/display/RoomImg.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Center } from '@chakra-ui/layout'
+import type { furnitureType } from '../../type/furnitureType'
+import FurnitureImg from './FurnitureImg'
+
+interface Props {
+  furnitureList: furnitureType[]
+}
+
+function RoomImg ({ furnitureList }: Props): JSX.Element {
+  return (
+    <>
+      <Center width='200px' height='200px' bg='#ECECEC'>
+        {furnitureList.map((furniture, index) => (
+          <FurnitureImg
+            key={index}
+            fileName={furniture.fileName}
+            imageSize={furniture.imageSize}
+            position={furniture.position}
+            rotation={furniture.rotation}
+          />
+        ))}
+        </Center>
+    </>
+  )
+}
+
+export default RoomImg

--- a/src/pages/List.tsx
+++ b/src/pages/List.tsx
@@ -11,9 +11,6 @@ interface Props {
 }
 
 function List ({ handleSignout }: Props): JSX.Element {
-  // TODO: 部屋の表示ができるようになったら削除する
-  const tempURL = 'https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhDl2-L1_SRV6R8sk3vPCGtO5vy8LEnpUSoaoEnCXBuItx89ag78Q3MxM6HtkUixlwiYw1cSK50-P0veLIMXpbT_w-wjcpxSeH7JDOe7r_oNeMe8bX_VsydNAj90vBr1Hm-PhR2V-UJ3O2pAkUmhU4d4mg_qMGlg5r7CmzKiZ_yJzQk24lR5acOGYVX6w/s845/pop_shinsyakaijin_murisuruna.png'
-
   // 取得した部屋の情報
   const [roomList, setRoomList] = useState<roomType[]>([])
 
@@ -49,7 +46,7 @@ function List ({ handleSignout }: Props): JSX.Element {
   const AllRooms: JSX.Element[] = roomList.map(({ roomName, furnitureList }: roomType, index: number) => {
     return (
       <WrapItem key={index}>
-        <RoomButton title={roomName} image={tempURL} type='green' onClick={() => { window.location.href = `/design/room_id_${index + 1}` }}/>
+        <RoomButton title={roomName} furnitureList={furnitureList} type='green' onClick={() => { window.location.href = `/design/room_id_${index + 1}` }}/>
       </WrapItem>
     )
   })


### PR DESCRIPTION
## 🔨 変更内容

- 部屋一覧画面で、DBに保存してある部屋のレイアウトを表示できるようにした

## 📸 スクリーンショット
![スクリーンショット 2024-05-01 105602](https://github.com/Imagiterior-continue/frontend/assets/117695575/b37f6bcc-8269-4a61-ab26-ef673f5dee67)

## 📢 この PR に含まないこと

- xxx

## 💡 レビューの観点

### PR 作成者のチェック項目

- [x] セルフレビュー
- [ ] CI/CD がすべて pass している
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #37 

## 🤝 関連するイシュー

- #0
