### PR TITLE
Feature/55 restrict char num: 部屋の名前の文字数の表示と制限

### DIFF
--- a/src/components/RoomForm.tsx
+++ b/src/components/RoomForm.tsx
@@ -20,7 +20,6 @@ function RoomForm ({ initialValue, setName }: Props): JSX.Element {
             type='text'
             placeholder='ここに入力'
             value={initialValue}
-            // onChange={handleInputChange}
             onChange={(e) => { setName(e.target.value) }}
             maxLength={maxLength}
           />


### PR DESCRIPTION
## 🔨 変更内容

- 部屋の名前の文字数を表示
- 部屋の名前の文字数を10文字までに制限

## 📸 スクリーンショット
![image](https://github.com/Imagiterior-continue/frontend/assets/148172486/2b82c5e3-a557-4c50-a08c-f732042d4196)


## 📢 この PR に含まないこと

- xxx

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] CI/CD がすべて pass している
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #55 

## 🤝 関連するイシュー

- #0
